### PR TITLE
remove hedss as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @hedss @shaunmulligan @xginn8 @garethtdavies @ZubairLK
+*       @shaunmulligan @xginn8 @garethtdavies @ZubairLK


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Matthew McGinn <matthew@balena.io>